### PR TITLE
Retry addition for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,5 +69,6 @@ To stop the playback, simply run the same command.
 
 ### Other Commands
 There are a few other commands you can currently run if you are a Spotify Premium User:
-- `:Spotify pause`: Pauses current song
-- `:Spotify resume`: Resumes current song
+- `:Spotify pause`: Pauses current song  
+- `:Spotify resume`: Resumes current song  
+- `:Spotify auth`: Re-authorizes with the Spotify app in case there are issues

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ LazyVim:
       },
 
       spotify = {
+         api_retry_max = 3,               -- The number of times to retry before failing out.
+         api_retry_backoff = 2000,
          auth = {
             premium = true,
          },

--- a/lua/smm/config.lua
+++ b/lua/smm/config.lua
@@ -20,6 +20,8 @@ local default_config = {
 
   spotify = {
     enabled = true,
+    api_retry_max = 3,
+    api_retry_backoff = 2000,
     auth = {
       premium = true,
       enabled = true,

--- a/lua/smm/config.lua
+++ b/lua/smm/config.lua
@@ -1,9 +1,9 @@
 local logger = require 'smm.utils.logger'
 
+---@alias SMM_Config { debug: boolean, playback: SMM_PlaybackConfig, spotify: SMM_SpotifyConfig }
 local M = {}
 
 local default_config = {
-  initialized = false,
   debug = false,
   -- file = '/home/klanum/smm_log.txt',
 
@@ -32,6 +32,7 @@ local default_config = {
 
 local config = {}
 
+---@param user_config SMM_Config
 function M.setup(user_config)
   if user_config.debug == nil then
     user_config.debug = false

--- a/lua/smm/playback/config.lua
+++ b/lua/smm/playback/config.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+---@alias SMM_PlaybackConfig { enabled: boolean, interface: SMM_PlaybackInterfaceConfig, timer_update_interval: integer, timer_sync_interval: integer }
+
 local config = nil
 
 function M.setup(user_config)

--- a/lua/smm/playback/init.lua
+++ b/lua/smm/playback/init.lua
@@ -44,7 +44,7 @@ local function handle_timer_sync(callback)
     else
       logger.error('Getting playback state failed:\nStatus Code: %s\nError: %s', status_code, vim.inspect(playback_response))
     end
-  end)
+  end, true)
 end
 
 ---@param current_ms integer|nil Current position in milliseconds

--- a/lua/smm/playback/init.lua
+++ b/lua/smm/playback/init.lua
@@ -36,7 +36,7 @@ local function handle_timer_sync(callback)
         callback(nil)
       end
     else
-      logger.error('Getting playback state failed:\nStatus Code: %s\nError: %s', status_code, playback_response)
+      logger.error('Getting playback state failed:\nStatus Code: %s\nError: %s', status_code, vim.inspect(playback_response))
     end
   end)
 end

--- a/lua/smm/playback/interface/config.lua
+++ b/lua/smm/playback/interface/config.lua
@@ -6,17 +6,17 @@ local M = {}
 --- | 'BottomLeft'
 --- | 'BottomRight'
 
----@alias SMM_InterfaceConfig { playback_pos: SMM_PlaybackWindowPosition, playback_width: integer, progress_bar_width: integer}
+---@alias SMM_PlaybackInterfaceConfig { playback_pos: SMM_PlaybackWindowPosition, playback_width: integer, progress_bar_width: integer}
 
----@type SMM_InterfaceConfig
+---@type SMM_PlaybackInterfaceConfig
 local config = {}
 
----@param user_config SMM_InterfaceConfig
+---@param user_config SMM_PlaybackInterfaceConfig
 function M.setup(user_config)
   config = user_config
 end
 
----@return SMM_InterfaceConfig
+---@return SMM_PlaybackInterfaceConfig
 function M.get()
   return config
 end

--- a/lua/smm/spotify/config.lua
+++ b/lua/smm/spotify/config.lua
@@ -2,7 +2,7 @@ local logger = require 'smm.utils.logger'
 
 local M = {}
 
----@alias SMM_SpotifyConfig { auth: SMM_SpotifyAuthConfig }
+---@alias SMM_SpotifyConfig { enabled: boolean, auth: SMM_SpotifyAuthConfig,  }
 
 ---@type SMM_SpotifyConfig
 local config = {}

--- a/lua/smm/spotify/config.lua
+++ b/lua/smm/spotify/config.lua
@@ -2,7 +2,7 @@ local logger = require 'smm.utils.logger'
 
 local M = {}
 
----@alias SMM_SpotifyConfig { enabled: boolean, auth: SMM_SpotifyAuthConfig,  }
+---@alias SMM_SpotifyConfig { enabled: boolean, api_retry_max: integer, api_retry_backoff: integer, auth: SMM_SpotifyAuthConfig,  }
 
 ---@type SMM_SpotifyConfig
 local config = {}

--- a/lua/smm/spotify/init.lua
+++ b/lua/smm/spotify/init.lua
@@ -2,6 +2,7 @@ local auth = require 'smm.spotify.auth'
 local token = require 'smm.spotify.token'
 local config = require 'smm.spotify.config'
 local logger = require 'smm.utils.logger'
+local requests = require 'smm.spotify.requests'
 
 local M = {}
 
@@ -23,6 +24,10 @@ end
 
 function M.setup(user_config)
   config.setup(user_config)
+
+  --- Inject retry configurations into the requests module specifically
+  requests.api_retry_max = config.get().api_retry_max
+  requests.api_retry_backoff = config.get().api_retry_backoff
 
   logger.debug 'Initializing Spotify - Auth Module Config'
   auth.setup(user_config.auth)

--- a/lua/smm/spotify/init.lua
+++ b/lua/smm/spotify/init.lua
@@ -7,7 +7,7 @@ local M = {}
 
 M.auth_info = nil
 
-local function authenticate()
+function M.authenticate()
   local refresh_token = token.load_refresh_token()
 
   if not refresh_token then
@@ -26,10 +26,6 @@ function M.setup(user_config)
 
   logger.debug 'Initializing Spotify - Auth Module Config'
   auth.setup(user_config.auth)
-
-  if M.auth_info == nil then
-    authenticate()
-  end
 end
 
 return M

--- a/lua/smm/spotify/requests.lua
+++ b/lua/smm/spotify/requests.lua
@@ -1,5 +1,7 @@
 local api = require 'smm.utils.api_async'
 local logger = require 'smm.utils.logger'
+local utils = require 'smm.spotify.utils'
+local config = require 'smm.spotify.config'
 
 local M = {}
 
@@ -20,14 +22,7 @@ local function check_session(auth_info)
   local current_time = os.time()
   logger.debug('Current Time: %d\nSession Expires atw %d\nSession remaining time: %d', current_time, auth_info.expires_at, auth_info.expires_at - current_time)
   if auth_info.expires_at < current_time + 30 then
-    local spotify = require 'smm.spotify'
-    local auth = require 'smm.spotify.auth'
-    local token = require 'smm.spotify.token'
-
-    local new_auth_info = auth.refresh_access_token(auth_info.refresh_token)
-    spotify.auth_info = new_auth_info
-    token.delete_refresh_token()
-    token.save_refresh_token(new_auth_info.refresh_token)
+    require('smm.spotify').authenticate()
   end
 end
 

--- a/lua/smm/spotify/requests.lua
+++ b/lua/smm/spotify/requests.lua
@@ -1,11 +1,16 @@
 local api = require 'smm.utils.api_async'
 local logger = require 'smm.utils.logger'
-local utils = require 'smm.spotify.utils'
 local config = require 'smm.spotify.config'
 
 local M = {}
 
 local base_url = 'https://api.spotify.com/v1'
+
+---@type integer
+M.api_retry_max = 0
+
+---@type integer
+M.api_retry_backoff = 0
 
 ---@param available_scope string
 ---@param scope_required string
@@ -26,8 +31,17 @@ local function check_session(auth_info)
   end
 end
 
+---@param api function
+---@param callback function
+local function retry(api, callback) end
+
 ---@param callback fun(response_body: string|table, response_headers: table, status_code: integer)
-function M.get_user_profile(callback)
+---@param retry? boolean
+function M.get_user_profile(callback, retry)
+  if retry == nil then
+    retry = true
+  end
+
   local auth_info = require('smm.spotify').auth_info
 
   if check_scope(auth_info.scope, 'user-read-private') then
@@ -39,7 +53,12 @@ function M.get_user_profile(callback)
 end
 
 ---@param callback fun(response_body: string|table, response_headers: table, status_code: integer)
-function M.get_playback_state(callback)
+---@param retry? boolean
+function M.get_playback_state(callback, retry)
+  if retry == nil then
+    retry = true
+  end
+
   local auth_info = require('smm.spotify').auth_info
 
   if check_scope(auth_info.scope, 'user-read-playback-state') then
@@ -51,7 +70,12 @@ function M.get_playback_state(callback)
 end
 
 ---@param callback fun(response_body: string|table, response_headers: table, status_code: integer)
-function M.pause_track(callback)
+---@param retry? boolean
+function M.pause_track(callback, retry)
+  if retry == nil then
+    retry = true
+  end
+
   local auth_info = require('smm.spotify').auth_info
 
   if check_scope(auth_info.scope, 'user-modify-playback-state') then
@@ -62,11 +86,16 @@ function M.pause_track(callback)
   end
 end
 
----@param context_uri string|nil
----@param offset integer|nil
+---@param context_uri string?
+---@param offset integer?
 ---@param position_ms integer
 ---@param callback fun(response_body: string|table, response_headers: table, status_code: integer)
-function M.resume_track(context_uri, offset, position_ms, callback)
+---@param retry? boolean
+function M.resume_track(context_uri, offset, position_ms, callback, retry)
+  if retry == nil then
+    retry = true
+  end
+
   local auth_info = require('smm.spotify').auth_info
 
   local body = {

--- a/lua/smm/spotify/utils.lua
+++ b/lua/smm/spotify/utils.lua
@@ -5,4 +5,10 @@ function M.get_spotify_state_path()
   return vim.fn.stdpath 'state' .. '/spotify'
 end
 
+---@param ms integer milliseconds to wait
+---@param callback function Function to call after the delay
+function M.sleep_async(ms, callback)
+  vim.defer_fn(callback, ms)
+end
+
 return M

--- a/lua/smm/utils/api_async.lua
+++ b/lua/smm/utils/api_async.lua
@@ -4,7 +4,7 @@ local logger = require 'smm.utils.logger'
 
 local M = {}
 
----@param headers table|nil
+---@param headers table?
 ---@return table
 local function prepare_headers(headers, access_token)
   if not headers then
@@ -54,8 +54,8 @@ end
 
 ---Make a GET Request
 ---@param url string The base URL
----@param headers table|nil Optional headers
----@param query table|nil
+---@param headers table? Optional headers
+---@param query table?
 ---@param access_token string
 ---@param callback fun(response_body: table|string, response_headers: table, status_code: integer) Callback Function
 function M.get(url, headers, query, access_token, callback)
@@ -74,8 +74,8 @@ end
 
 ---Make a POST Request
 ---@param url string The base URL
----@param headers table|nil Optional headers
----@param query table|nil Optional Query
+---@param headers table? Optional headers
+---@param query table? Optional Query
 ---@param body table|string Required Body (will be encoded as JSON if Content-Type not specified)
 ---@param access_token string
 ---@param callback fun(response_body: table|string, response_headers: table, status_code: integer) Callback Function
@@ -114,9 +114,9 @@ end
 
 --- Make a PUT Request
 ---@param url string The base URL
----@param headers table|nil Optional Headers
----@param query table|nil Optional Query
----@param body table|string|nil Request body (will be encoded as JSON if Content-Type not specified)
+---@param headers table? Optional Headers
+---@param query table? Optional Query
+---@param body table|string? Request body (will be encoded as JSON if Content-Type not specified)
 ---@param access_token string Authorization Access Token
 ---@param callback fun(response_body: table|string, response_headers: table, status_code: integer) Callback Function
 function M.put(url, headers, query, body, access_token, callback)


### PR DESCRIPTION
Adds extra logic in the Spotify `smm.spotify.requests.lua` file to ensure that if rate limiting or server errors occur then it automatically runs a retry.