### PR TITLE
Switches socket over to vim.uv.new_tcp()

### DIFF
--- a/lua/smm/spotify/auth/init.lua
+++ b/lua/smm/spotify/auth/init.lua
@@ -43,6 +43,10 @@ function M.initiate_oauth_flow()
 
   local oauth_code = sock.start_server(port, state)
 
+  if oauth_code == nil then
+    return
+  end
+
   local auth_info = requests.get_access_token(oauth_code, code_verifier, redirect_uri)
 
   return auth_info


### PR DESCRIPTION
Removes the need for an external lua socket module by using neovims buil-in `vim.uv.new_tcp()`

Fixes #31 
