### PR TITLE
Manager fixes and memory leak reduction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this project is
+
+smm.nvim is a Neovim plugin that connects to the Spotify Web API to display and control Spotify playback from inside Neovim. It does not stream audio — it remote-controls whatever Spotify client is already open on the user's devices.
+
+Dependencies: `nvim-lua/plenary.nvim` (HTTP, async), `nvim-telescope/telescope.nvim` (search UI).
+
+## Formatting
+
+This project uses [StyLua](https://github.com/JohnnyMorganz/StyLua). Run it with:
+
+```
+stylua .
+```
+
+Key style rules (from `.stylua.toml`): 2-space indent, single quotes preferred, no call parentheses, 160-column width, Unix line endings.
+
+## Architecture
+
+### Entry points
+
+- `plugin/smm.lua` — Neovim plugin loader; calls `require('smm').setup(config)`
+- `lua/smm/init.lua` — `M.setup()` wires together the three subsystems: `spotify`, `playback`, `search`
+- `lua/smm/commands.lua` — registers the `:Spotify` user command; routes sub-commands to `playback` module functions
+
+### Subsystems
+
+**`lua/smm/spotify/`** — Spotify authentication and API
+
+- `auth/init.lua` — OAuth PKCE flow: opens browser, starts a local socket server to receive the callback, exchanges code for tokens
+- `auth/sock.lua` — temporary TCP server that captures the OAuth redirect
+- `auth/requests.lua` — token exchange and refresh HTTP calls (synchronous, via `utils/api_sync.lua`)
+- `token.lua` — persists the refresh token to `$HOME/.local/state/nvim/spotify/refresh_token` as AES-256-CBC ciphertext (via openssl CLI)
+- `requests.lua` — all Spotify Web API calls (GET/PUT/POST/DELETE); each function checks token scope, auto-refreshes the access token if it expires within 30 s, and wraps the call in retry logic for 5xx/429 responses
+- `init.lua` — `M.authenticate()` orchestrates token load-or-OAuth, then checks/updates the account type (free vs. premium)
+
+**`lua/smm/playback/`** — the running playback session
+
+- `manager.lua` — owns the session state (`playback_info`, the timer). `start_session()` creates a `Timer` and wires it to handler closures. `stop_session()` tears everything down.
+- `timer.lua` — `SMM_PlaybackTimer` wraps `vim.uv.new_timer()`. Every `timer_update_interval` ms it increments `current_pos` and calls `update`; every `timer_sync_interval` ms it calls `sync` (an async Spotify API fetch) to re-anchor the position.
+- `handlers.lua` — factory functions (e.g. `create_sync_handler`, `create_pause_handler`) that return closures. The manager calls these factories once and stores the results. Each handler calls a function in `spotify/requests.lua` and mutates playback state on success.
+- `init.lua` — public API consumed by `commands.lua`: `toggle_window`, `pause`, `resume`, `play`, `next`, `previous`, etc. Also owns the `SMM_UI_Window` instance and extmark-based clickable song links.
+- `utils.lua` — formats a `SMM_PlaybackInfo` table into lines for the floating window
+
+**`lua/smm/search/`** — Telescope pickers
+
+- `media.lua` — parses Spotify search results into model objects, presents a Telescope picker, calls back with the selected item
+- `device.lua` — same pattern for device selection
+
+**`lua/smm/models/`** — data model classes
+
+- `base.lua` — `SMM_BaseMedia` base class with `id`, `name`, `uri`, `external_urls`; `get_spotify_url()` reads `external_urls.spotify`
+- `track.lua`, `album.lua`, `artist.lua`, `playlist.lua`, `device.lua` — inherit from `BaseMedia` (or define standalone) and add type-specific fields
+- `ui/interface.lua` — `SMM_UI_Window` class: creates/updates/closes a `nvim_open_win` floating window; applies Spotify-green highlight
+- `ui/utils.lua` — computes `row`/`col` for each of the four corner positions and `Center`
+
+**`lua/smm/utils/`** — shared utilities
+
+- `api_async.lua` — thin wrapper around `plenary.curl` for async GET/POST/PUT/DELETE; attaches `Authorization: Bearer` header and parses JSON responses
+- `api_sync.lua` — synchronous version used only by auth token exchange
+- `crypto.lua` — AES-256-CBC encrypt/decrypt via the `openssl` CLI (PBKDF2 key from machine-id + `$HOME`); also PKCE helpers (SHA-256, URL-safe base64)
+- `encoding.lua` — URL query-string and JSON encoding helpers
+- `logger.lua` — wraps `vim.notify` with debug/info/warn/error levels; enabled only when `config.debug = true`
+- `os.lua` — `open_browser(url)` cross-platform helper
+
+### Data flow for a playback update
+
+1. `Timer` fires every `timer_update_interval` ms → calls `update_handler(current_pos)`
+2. `update_handler` (from `handlers.create_update_handler`) increments `playback_info.progress_ms`, calls `on_interface_update` → `playback.update_playback_window` re-renders the float
+3. Every `timer_sync_interval` ms → `sync_handler` fires `spotify/requests.get_playback_state` (async) → result parsed by `playback/utils.get_playbackinfo` → `manager.playback_info` updated → timer re-anchored
+
+### Token security model
+
+The refresh token is encrypted before writing to disk. The AES-256 key is derived from a SHA-256 hash of `"smm.nvim:v1:" + machine_id + ":" + $HOME`. Legacy plaintext tokens are migrated automatically on first load.

--- a/lua/smm/playback/init.lua
+++ b/lua/smm/playback/init.lua
@@ -42,8 +42,6 @@ local function setup_track_link(buf, playback_info)
 
   local track = playback_info.track
 
-  vim.api.nvim_set_hl(0, 'SMMTrackLink', { fg = '#1ED760', underdotted = true })
-
   local artist_url = track.artists[1] and track.artists[1]:get_spotify_url() or ''
   if artist_url ~= '' then
     set_link(buf, ARTIST_LINE, artist_url)
@@ -124,6 +122,7 @@ function M.toggle_window()
   local title = ' Spotify '
 
   M.playback_window = Window:new(title, lines, width, height, position)
+  vim.api.nvim_set_hl(0, 'SMMTrackLink', { fg = '#1ED760', underdotted = true })
 
   logger.debug 'Starting playback session'
   manager.start_session()

--- a/lua/smm/playback/init.lua
+++ b/lua/smm/playback/init.lua
@@ -20,6 +20,7 @@ local TRACK_LINE = 3
 local LEFT_PAD = 2
 
 local last_track_id = nil
+local last_title = nil
 local cached_links = nil
 
 -- Reads buffer line to compute extmark positions, sets the extmark, and returns
@@ -102,18 +103,18 @@ function M.update_playback_window(playback_info)
         title = title .. '- S '
       end
 
-      logger.debug('"%s"', playback_info.repeat_state)
       if playback_info.repeat_state == 'context' then
         title = title .. '- R '
       elseif playback_info.repeat_state == 'track' then
         title = title .. '- RT '
       end
 
-      logger.debug('"%s"', title)
-
-      M.playback_window:__set_opts {
-        title = M.playback_window:__create_title(title),
-      }
+      if title ~= last_title then
+        last_title = title
+        M.playback_window:__set_opts {
+          title = M.playback_window:__create_title(title),
+        }
+      end
     end
   end
 end
@@ -130,6 +131,7 @@ function M.toggle_window()
     logger.debug 'Hiding playback window'
     M.playback_window:close()
     last_track_id = nil
+    last_title = nil
     cached_links = nil
 
     if manager.is_session_active() then

--- a/lua/smm/playback/init.lua
+++ b/lua/smm/playback/init.lua
@@ -19,6 +19,11 @@ local ALBUM_LINE = 2
 local TRACK_LINE = 3
 local LEFT_PAD = 2
 
+local last_track_id = nil
+local cached_links = nil
+
+-- Reads buffer line to compute extmark positions, sets the extmark, and returns
+-- the { line_nr, col_start, col_end, url } entry for later re-application.
 local function set_link(buf, line_nr, url)
   local line = vim.api.nvim_buf_get_lines(buf, line_nr, line_nr + 1, false)[1] or ''
   local name_start = select(2, line:find(': ', 1, true)) or LEFT_PAD
@@ -29,11 +34,28 @@ local function set_link(buf, line_nr, url)
     hl_group = 'SMMTrackLink',
     url = url,
   })
+  return { line_nr, name_start, end_col, url }
+end
+
+-- Re-applies cached link positions without reading from the buffer.
+-- Called every tick after nvim_buf_set_lines destroys extmarks.
+local function apply_cached_links(buf)
+  vim.api.nvim_buf_clear_namespace(buf, ns_id, 0, -1)
+  if not cached_links then return end
+  for _, link in ipairs(cached_links) do
+    vim.api.nvim_buf_set_extmark(buf, ns_id, link[1], link[2], {
+      end_row = link[1],
+      end_col = link[3],
+      hl_group = 'SMMTrackLink',
+      url = link[4],
+    })
+  end
 end
 
 ---@param buf integer
 ---@param playback_info SMM_PlaybackInfo|nil
 local function setup_track_link(buf, playback_info)
+  cached_links = nil
   vim.api.nvim_buf_clear_namespace(buf, ns_id, 0, -1)
 
   if not playback_info or not playback_info.track then
@@ -41,20 +63,21 @@ local function setup_track_link(buf, playback_info)
   end
 
   local track = playback_info.track
+  cached_links = {}
 
   local artist_url = track.artists[1] and track.artists[1]:get_spotify_url() or ''
   if artist_url ~= '' then
-    set_link(buf, ARTIST_LINE, artist_url)
+    table.insert(cached_links, set_link(buf, ARTIST_LINE, artist_url))
   end
 
   local album_url = track.album and track.album:get_spotify_url() or ''
   if album_url ~= '' then
-    set_link(buf, ALBUM_LINE, album_url)
+    table.insert(cached_links, set_link(buf, ALBUM_LINE, album_url))
   end
 
   local track_url = track:get_spotify_url()
   if track_url ~= '' then
-    set_link(buf, TRACK_LINE, track_url)
+    table.insert(cached_links, set_link(buf, TRACK_LINE, track_url))
   end
 end
 
@@ -64,9 +87,13 @@ function M.update_playback_window(playback_info)
     local lines = utils.format_playback_lines(playback_info)
     M.playback_window:update_window(lines)
     if config.get().song_links then
-      setup_track_link(M.playback_window.buf, playback_info)
-    else
-      vim.api.nvim_buf_clear_namespace(M.playback_window.buf, ns_id, 0, -1)
+      local current_track_id = playback_info and playback_info.track and playback_info.track.id
+      if current_track_id ~= last_track_id then
+        last_track_id = current_track_id
+        setup_track_link(M.playback_window.buf, playback_info)
+      else
+        apply_cached_links(M.playback_window.buf)
+      end
     end
 
     if playback_info then
@@ -102,6 +129,8 @@ function M.toggle_window()
   if M.playback_window and M.playback_window.is_showing then
     logger.debug 'Hiding playback window'
     M.playback_window:close()
+    last_track_id = nil
+    cached_links = nil
 
     if manager.is_session_active() then
       logger.debug 'Stopping session playback'

--- a/lua/smm/playback/manager.lua
+++ b/lua/smm/playback/manager.lua
@@ -300,7 +300,7 @@ end
 --- Add the current song to liked songs
 function M.add_song_to_liked_songs()
   if like_song_handler then
-    current_id = playback_info.track.id
+    local current_id = playback_info.track.id
     like_song_handler(current_id)
   end
 end
@@ -308,7 +308,7 @@ end
 --- Remove the current song from liked songs
 function M.remove_song_from_liked_songs()
   if unlike_song_handler then
-    current_id = playback_info.track.id
+    local current_id = playback_info.track.id
     unlike_song_handler(current_id)
   end
 end

--- a/lua/smm/playback/manager.lua
+++ b/lua/smm/playback/manager.lua
@@ -243,21 +243,7 @@ function M.sync()
   end
 
   logger.debug 'Syncing'
-  if sync_handler then
-    sync_handler(function(sync_data)
-      logger.debug('[TIMER] Sync callback received - has_data: %s', tostring(sync_data ~= nil))
-      if sync_data then
-        timer.current_pos = sync_data.current_pos
-        timer.is_updating = sync_data.is_playing
-        logger.debug('[TIMER] Sync updated - pos: %d, playing: %s', sync_data.current_pos, tostring(sync_data.is_playing))
-        timer.update(timer.current_pos)
-      else
-        logger.debug '[TIMER] Sync returned nil, pausing timer'
-        timer:pause()
-        timer.update(nil)
-      end
-    end)
-  end
+  timer:force_sync()
 end
 
 ---Change the shuffle state

--- a/lua/smm/playback/manager.lua
+++ b/lua/smm/playback/manager.lua
@@ -157,6 +157,15 @@ function M.stop_session()
   update_handler = nil
   pause_handler = nil
   play_handler = nil
+  next_handler = nil
+  previous_handler = nil
+  transfer_playback_handler = nil
+  shuffle_handler = nil
+  repeat_handler = nil
+  media_search_handler = nil
+  device_search_handler = nil
+  like_song_handler = nil
+  unlike_song_handler = nil
 end
 
 ---Checks if session is running

--- a/lua/smm/playback/timer.lua
+++ b/lua/smm/playback/timer.lua
@@ -97,6 +97,20 @@ function Timer:reset()
   self.current_pos = 0
 end
 
+function Timer:force_sync()
+  if not self.sync then return end
+  self.sync(function(sync_data)
+    if sync_data then
+      self.current_pos = sync_data.current_pos
+      self.is_updating = sync_data.is_playing
+      self.update(self.current_pos)
+    else
+      self:pause()
+      self.update(nil)
+    end
+  end)
+end
+
 function Timer:close()
   self:pause()
   self:reset()


### PR DESCRIPTION
  Title: Cleanup: manager fixes and memory leak reduction

  Body:

  Summary

  - Adds CLAUDE.md codebase documentation
  - Fixes stop_session() only nilling 4 of 13 handlers, leaving closures allocated after session close
  - Fixes implicit global current_id variable in liked song handlers
  - Encapsulates sync callback logic inside Timer:force_sync() instead of manager reaching into timer internals
  - Moves nvim_set_hl out of the 100ms update loop (was called 10x/sec, never changed)
  - Caches track link extmark positions on track change; re-applies cheaply each tick without re-reading buffer lines — also fixes links disappearing after pause/resume
  - Guards window title __set_opts with an equality check to skip redundant vim.tbl_deep_extend calls when shuffle/repeat state is unchanged

  Test plan

  - Open playback window with :Spotify, confirm song links are clickable
  - Pause and resume — confirm links remain visible
  - Skip to next track — confirm links update to new track
  - Toggle shuffle/repeat — confirm title indicators (S, R, RT) update correctly
  - Close and reopen playback window — confirm full re-render on open


